### PR TITLE
sync with Haxe changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ haxelib git safety https://github.com/RealyUniqueName/Safety.git
 Prebuilt plugin binaries are compatible with Haxe 4.0.0-preview.3 and x64 systems Windows, OSX and Linux. If you want to use null safety plugin with another OS, arch or another version of Haxe you need to setup desired version of Haxe for development (see [Building Haxe from source](https://haxe.org/documentation/introduction/building-haxe.html)) and then
 ```
 cd path/to/haxe-source/
-make PLUGIN=path/to/safety/src/ml/safety plugin
+make PLUGIN=path/to/safety/src/ml/safety_plugin plugin
 ```
 
 ## Usage

--- a/src/ml/safety_plugin.ml
+++ b/src/ml/safety_plugin.ml
@@ -1548,7 +1548,7 @@ class plugin =
 				let obj = encode_obj_s
 					vnull
 					[
-						("msg", vstring (Rope.of_string msg));
+						("msg", encode_rope (Rope.of_string msg));
 						("pos", encode_pos p)
 					]
 				in


### PR DESCRIPTION
`vstring` now takes the new `vstring` structure instead of a `Rope.t`. I don't know if that part has to support unicode.

Also fix the plugin path in readme.md.